### PR TITLE
ZSH-compatibility for the IPv6 launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Full Test       | https://browser.geekbench.com/v5/cpu/3844555
 
 GitHub's CDN does not resolve via IPv6. You will need to run the following command to download and run the script.
 
-`curl -s -k -g --header 'Host: raw.githubusercontent.com' https://[2a04:4e42::133]/masonr/yet-another-bench-script/master/yabs.sh | bash`
+`curl -s -k -g --header 'Host: raw.githubusercontent.com' "https://[2a04:4e42::133]/masonr/yet-another-bench-script/master/yabs.sh" | bash`
 
 (2a04:4e42::133 is fastly.net's [GitHub's CDN Provider] IPv6 address)
 


### PR DESCRIPTION
The IPv6-compatible launch command in the README.md uses square brackets. Square brackets are fine in `bash`, but they do have a special meaning in `zsh`. However, there is an easy way around it: wrap the URL in "". This doesn't harm `bash` but also makes the command copy&pastable in `zsh`.