### PR TITLE
Use fenced code blocks for "How to Run" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ View YABS usage stats [here](https://yabs.rowe.sh).
 
 ## How to Run
 
-`curl -sL yabs.sh | bash` 
+```
+curl -sL yabs.sh | bash
+```
 
 or 
 
-`wget -qO- yabs.sh | bash`
+```
+wget -qO- yabs.sh | bash
+```
 
 This script has been tested on the following Linux distributions: CentOS 6+, Debian 8+, Fedora 30, and Ubuntu 16.04+. It is designed to not require any external dependencies to be installed nor elevated privileges to run.
 


### PR DESCRIPTION
The advantage of using fenced code blocks as opposed to inline code blocks is that the fenced code blocks have a copy button so you don't have to highlight the contents of the code block:

<img width="62" alt="image" src="https://user-images.githubusercontent.com/174864/197603748-2f78e72f-7385-4dea-9316-c0cbd92032d8.png">
