### PR TITLE
Consistent Enforcement of the Speed Test Location Naming

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -725,8 +725,8 @@ if [ -z "$SKIP_IPERF" ]; then
 	#   5. network modes supported by the iperf server (IPv4 = IPv4-only, IPv4|IPv6 = IPv4 + IPv6, etc.)
 	IPERF_LOCS=( \
 		"lon.speedtest.clouvider.net" "5200-5209" "Clouvider" "London, UK (10G)" "IPv4|IPv6" \
-		"ping.online.net" "5200-5209" "Online.net" "Paris, FR (10G)" "IPv4" \
-		"ping6.online.net" "5200-5209" "Online.net" "Paris, FR (10G)" "IPv6" \
+		"ping.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv4" \
+		"ping6.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv6" \
 		"speedtest-nl-oum.hybula.net" "5201-5206" "Hybula" "The Netherlands (40G)" "IPv4|IPv6" \
 		"speedtest.uztelecom.uz" "5200-5207" "Uztelecom" "Tashkent, UZ (10G)" "IPv4|IPv6" \
 		"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "NYC, NY, US (10G)" "IPv4|IPv6" \

--- a/yabs.sh
+++ b/yabs.sh
@@ -727,7 +727,7 @@ if [ -z "$SKIP_IPERF" ]; then
 		"lon.speedtest.clouvider.net" "5200-5209" "Clouvider" "London, UK (10G)" "IPv4|IPv6" \
 		"ping.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv4" \
 		"ping6.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv6" \
-		"speedtest-nl-oum.hybula.net" "5201-5206" "Hybula" "The Netherlands (40G)" "IPv4|IPv6" \
+		"speedtest-nl-oum.hybula.net" "5201-5206" "Hybula" "North Holland, NL (40G)" "IPv4|IPv6" \
 		"speedtest.uztelecom.uz" "5200-5207" "Uztelecom" "Tashkent, UZ (10G)" "IPv4|IPv6" \
 		"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "NYC, NY, US (10G)" "IPv4|IPv6" \
 		"dal.speedtest.clouvider.net" "5200-5209" "Clouvider" "Dallas, TX, US (10G)" "IPv4|IPv6" \


### PR DESCRIPTION
I'd like to make a few suggestions to the naming of the `iperf`-locations, as there are a few inconsistencies that bug me as a perfectionist:

1. **Online.net rebranded to Scaleway** a few years ago. I think its time to reflect that in the YABS output.

2. All probes have their location stored as `<CITY>, <COUNTRY_CODE>` except for one: _"Hybula | The Netherlands (40G)"_. I think that should say something like **_"Hybula | North Holland, NL (40G)"_**.

3. ... or even better _"NovoServe | North Holland, NL (40G)"_ as `speedtest-nl-oum.hybula.net` is just a redirect to `speedtest.novoserve.com` and it's NovoServes network after all.

But as 3. isn't for me to decide, this push request only includes the suggested changes for 1. and 2.

---

Here is an example how the YABS output would look after applying the suggested patches:

```
iperf3 Network Speed Tests (IPv4):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed     
                |                           |                 |                
Clouvider       | London, UK (10G)          | 2.69 Gbits/sec  | 2.70 Gbits/sec 
Scaleway        | Paris, FR (10G)           | 2.69 Gbits/sec  | 2.69 Gbits/sec 
Hybula          | North Holland, NL (40G)   | 2.68 Gbits/sec  | 2.70 Gbits/sec 
Uztelecom       | Tashkent, UZ (10G)        | 2.69 Gbits/sec  | 2.69 Gbits/sec 
Clouvider       | NYC, NY, US (10G)         | 1.91 Gbits/sec  | 1.98 Gbits/sec 
Clouvider       | Dallas, TX, US (10G)      | 1.18 Gbits/sec  | 1.48 Gbits/sec 
Clouvider       | Los Angeles, CA, US (10G) | 1.18 Gbits/sec  | 1.19 Gbits/sec 

iperf3 Network Speed Tests (IPv6):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed     
                |                           |                 |                
Clouvider       | London, UK (10G)          | 2.69 Gbits/sec  | 2.69 Gbits/sec 
Scaleway        | Paris, FR (10G)           | 2.69 Gbits/sec  | 2.69 Gbits/sec 
Hybula          | North Holland, NL (40G)   | 2.69 Gbits/sec  | 2.69 Gbits/sec 
Uztelecom       | Tashkent, UZ (10G)        | 1.19 Gbits/sec  | 2.41 Gbits/sec 
Clouvider       | NYC, NY, US (10G)         | 1.94 Gbits/sec  | 1.97 Gbits/sec 
Clouvider       | Dallas, TX, US (10G)      | 1.25 Gbits/sec  | 1.42 Gbits/sec 
Clouvider       | Los Angeles, CA, US (10G) | 1.01 Gbits/sec  | 1.18 Gbits/sec 
```
