### PR TITLE
Add Basic Network Info and VM Type

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Yet Another Bench Script by Mason Rowe
-# Initial Oct 2019; Last update Dec 2022
+# Initial Oct 2019; Last update Jan 2023
 
 # Disclaimer: This project is a work in progress. Any errors or suggestions should be
 #             relayed to me via the GitHub project page linked below.
@@ -12,7 +12,7 @@
 #             performance via fio. The script is designed to not require any dependencies
 #             - either compiled or installed - nor admin privileges to run.
 #
-YABS_VERSION="v2022-12-29"
+YABS_VERSION="v2023-01-21"
 
 echo -e '# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## #'
 echo -e '#              Yet-Another-Bench-Script              #'
@@ -242,6 +242,65 @@ DISTRO=$(grep 'PRETTY_NAME' /etc/os-release | cut -d '"' -f 2 )
 echo -e "Distro     : $DISTRO"
 KERNEL=$(uname -r)
 echo -e "Kernel     : $KERNEL"
+
+# Function to get information from IP Address using ip-api.com free API
+function ip_info() {
+    local net_type="$(wget -qO- http://ip6.me/api/ | cut -d, -f1)"
+    local net_ip="$(wget -qO- http://ip6.me/api/ | cut -d, -f2)"
+
+    local response=$(wget -qO- http://ip-api.com/json/$net_ip)
+
+    local country=$(echo "$response" | grep -Po '"country": *\K"[^"]*"')
+    local country=${country//\"}
+
+    local region=$(echo "$response" | grep -Po '"regionName": *\K"[^"]*"')
+    local region=${region//\"}
+
+    local region_code=$(echo "$response" | grep -Po '"region": *\K"[^"]*"')
+    local region_code=${region_code//\"}
+
+    local city=$(echo "$response" | grep -Po '"city": *\K"[^"]*"')
+    local city=${city//\"}
+
+    local isp=$(echo "$response" | grep -Po '"isp": *\K"[^"]*"')
+    local isp=${isp//\"}
+
+    local org=$(echo "$response" | grep -Po '"org": *\K"[^"]*"')
+    local org=${org//\"}
+
+    local as=$(echo "$response" | grep -Po '"as": *\K"[^"]*"')
+    local as=${as//\"}
+    
+
+    if [[ -n "$net_type" ]]; then
+        echo "Protocol   : $net_type"
+    fi
+	if [[ -z "$net_type" ]]; then
+        echo "Network    : Unknown"
+    fi
+    if [[ -n "$isp" && -n "$as" ]]; then
+        echo "ISP        : $isp"
+        echo "ASN        : $as"
+    fi
+    if [[ -n "$org" ]]; then
+        echo "Host       : $org"
+    fi
+    if [[ -n "$city" && -n "$region" ]]; then
+        echo "Location   : $city, $region ($region_code)"
+    fi
+    if [[ -n "$country" ]]; then
+        echo "Country    : $country"
+    fi
+    if [[ -z "$org" ]]; then
+        echo "Host       : No ISP detected"
+    fi    
+}
+
+echo -e 
+echo -e "Basic Network Information:"
+echo -e "---------------------------------"
+ip_info
+
 
 if [ ! -z $JSON ]; then
 	UPTIME_S=$(awk '{print $1}' /proc/uptime)

--- a/yabs.sh
+++ b/yabs.sh
@@ -82,11 +82,11 @@ check_virt() {
         sys_product=""
         sys_ver=""
     fi
-    if grep -qa docker /proc/1/cgroup; then
+    if grep -qa docker /proc/1/cgroup 2>/dev/null; then
         VIRT="Docker"
-    elif grep -qa lxc /proc/1/cgroup; then
+    elif grep -qa lxc /proc/1/cgroup 2>/dev/null; then
         VIRT="LXC"
-    elif grep -qa container=lxc /proc/1/environ; then
+    elif grep -qa container=lxc /proc/1/environ 2>/dev/null; then
         VIRT="LXC"
     elif [[ -f /proc/user_beancounters ]]; then
         VIRT="OpenVZ"
@@ -123,7 +123,7 @@ check_virt() {
             fi
         fi
     else
-        VIRT="Dedicated"
+        VIRT="Dedicated/Unknown"
     fi
 }
 

--- a/yabs.sh
+++ b/yabs.sh
@@ -58,6 +58,75 @@ else
 	exit 1
 fi
 
+# Functions to identify virtualization type of host system
+_exists() {
+    local cmd="$1"
+    if eval type type > /dev/null 2>&1; then
+        eval type "$cmd" > /dev/null 2>&1
+    elif command > /dev/null 2>&1; then
+        command -v "$cmd" > /dev/null 2>&1
+    else
+        which "$cmd" > /dev/null 2>&1
+    fi
+    local rt=$?
+    return ${rt}
+}
+check_virt() {
+    _exists "dmesg" && virtualx="$(dmesg 2>/dev/null)"
+    if _exists "dmidecode"; then
+        sys_manu="$(dmidecode -s system-manufacturer 2>/dev/null)"
+        sys_product="$(dmidecode -s system-product-name 2>/dev/null)"
+        sys_ver="$(dmidecode -s system-version 2>/dev/null)"
+    else
+        sys_manu=""
+        sys_product=""
+        sys_ver=""
+    fi
+    if grep -qa docker /proc/1/cgroup; then
+        VIRT="Docker"
+    elif grep -qa lxc /proc/1/cgroup; then
+        VIRT="LXC"
+    elif grep -qa container=lxc /proc/1/environ; then
+        VIRT="LXC"
+    elif [[ -f /proc/user_beancounters ]]; then
+        VIRT="OpenVZ"
+    elif [[ "${virtualx}" == *kvm-clock* ]]; then
+        VIRT="KVM"
+    elif [[ "${sys_product}" == *KVM* ]]; then
+        VIRT="KVM"
+    elif [[ "${cname}" == *KVM* ]]; then
+        VIRT="KVM"
+    elif [[ "${cname}" == *QEMU* ]]; then
+        VIRT="KVM"
+    elif [[ "${virtualx}" == *"VMware Virtual Platform"* ]]; then
+        VIRT="VMware"
+    elif [[ "${sys_product}" == *"VMware Virtual Platform"* ]]; then
+        VIRT="VMware"
+    elif [[ "${virtualx}" == *"Parallels Software International"* ]]; then
+        VIRT="Parallels"
+    elif [[ "${virtualx}" == *VirtualBox* ]]; then
+        VIRT="VirtualBox"
+    elif [[ -e /proc/xen ]]; then
+        if grep -q "control_d" "/proc/xen/capabilities" 2>/dev/null; then
+            VIRT="Xen-Dom0"
+        else
+            VIRT="Xen-DomU"
+        fi
+    elif [ -f "/sys/hypervisor/type" ] && grep -q "xen" "/sys/hypervisor/type"; then
+        VIRT="Xen"
+    elif [[ "${sys_manu}" == *"Microsoft Corporation"* ]]; then
+        if [[ "${sys_product}" == *"Virtual Machine"* ]]; then
+            if [[ "${sys_ver}" == *"7.0"* || "${sys_ver}" == *"Hyper-V" ]]; then
+                VIRT="Hyper-V"
+            else
+                VIRT="Microsoft Virtual Machine"
+            fi
+        fi
+    else
+        VIRT="Dedicated"
+    fi
+}
+
 # flags to skip certain performance tests
 unset PREFER_BIN SKIP_FIO SKIP_IPERF SKIP_GEEKBENCH PRINT_HELP REDUCE_NET GEEKBENCH_4 GEEKBENCH_5 DD_FALLBACK IPERF_DL_FAIL JSON JSON_SEND JSON_RESULT JSON_FILE
 GEEKBENCH_5="True" # gb5 test enabled by default
@@ -242,6 +311,8 @@ DISTRO=$(grep 'PRETTY_NAME' /etc/os-release | cut -d '"' -f 2 )
 echo -e "Distro     : $DISTRO"
 KERNEL=$(uname -r)
 echo -e "Kernel     : $KERNEL"
+check_virt
+echo -e "VM Type    : $VIRT"
 
 # Function to get information from IP Address using ip-api.com free API
 function ip_info() {


### PR DESCRIPTION
Thought having a VM Type in Basic System Info and a Basic Network Info would make the YABS more informative/complete.

**Sample outputs:**

_OpenVZ, IPv6_
```
Basic System Information:
---------------------------------
Uptime     : 45 days, 8 hours, 34 minutes
Processor  : AMD EPYC 7452 32-Core Processor
CPU cores  : 1 @ 2113.623 MHz
AES-NI     : ✔ Enabled
VM-x/AMD-V : ✔ Enabled
RAM        : 256.0 MiB
Swap       : 128.0 MiB
Disk       : 3.9 GiB
Distro     : Ubuntu 18.04.6 LTS
Kernel     : 4.15.0
VM Type    : OpenVZ

Basic Network Information:
---------------------------------
Protocol   : IPv6
ISP        : NextGenWebs, S.L.
ASN        : AS41608 NextGenWebs, S.L.
Host       : NextGenWebs, S.L.
Location   : Amsterdam, North Holland (NH)
Country    : Netherlands

```

_KVM, IPv4_
```
Basic System Information:
---------------------------------
Uptime     : 13 days, 19 hours, 48 minutes
Processor  : AMD Ryzen 9 3900X 12-Core Processor
CPU cores  : 1 @ 3792.872 MHz
AES-NI     : ✔ Enabled
VM-x/AMD-V : ❌ Disabled
RAM        : 1.4 GiB
Swap       : 1.5 GiB
Disk       : 20.1 GiB
Distro     : Ubuntu 22.04 LTS
Kernel     : 5.15.0-57-generic
VM Type    : KVM

Basic Network Information:
---------------------------------
Protocol   : IPv4
ISP        : ColoCrossing
ASN        : AS36352 ColoCrossing
Host       : RackNerd LLC
Location   : Buffalo, New York (NY)
Country    : United States

```

_Windows_
```
Basic System Information:
---------------------------------
Uptime     : 0 days, 0 hours, 10 minutes
Processor  : AMD Ryzen 7 5800H with Radeon Graphics
CPU cores  : 16 @ 3193.915 MHz
AES-NI     : ✔ Enabled
VM-x/AMD-V : ✔ Enabled
RAM        : 6.7 GiB
Swap       : 2.0 GiB
Disk       : 250.9 GiB
Distro     : Ubuntu 22.04.1 LTS
Kernel     : 5.15.79.1-microsoft-standard-WSL2
VM Type    : WSL
```