### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Sites supporting submission of YABS JSON results:
 | Website | Example Command |
 | --- | --- |
 | [YABSdb](https://yabsdb.com/) | `curl -sL yabs.sh \| bash -s -- -s "https://yabsdb.com/add"` |
-| [VPSBenchmarks](https://www.vpsbenchmarks.com/yabs/get_started) | `curl -sL yabs.sh \| bash -s -- -5 -6 -s https://www.vpsbenchmarks.com/yabs/upload` |
+| [VPSBenchmarks](https://www.vpsbenchmarks.com/yabs/get_started) | `curl -sL yabs.sh \| bash -s -- -s https://www.vpsbenchmarks.com/yabs/upload` |
 | [s0c Online](https://s0c.org/) | `curl -sL yabs.sh \| bash -s -- -s https://s0c.org/api/yabs -9` |
 
 Example JSON output: [example.json](bin/example.json).


### PR DESCRIPTION
VPSBenchmarks does not require Geekbench 5 results anymore, there's no longer a need for the "-5 -6" command line options.