### PR TITLE
Add Leaseweb's iperf servers for a more diverse representation of North America

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -823,7 +823,7 @@ if [ -z "$SKIP_IPERF" ]; then
 		"speedtest.uztelecom.uz" "5200-5207" "Uztelecom" "Tashkent, UZ (10G)" "IPv4|IPv6" \
 		"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "New York City, US (10G)" "IPv4|IPv6" \
 		"speedtest.lax11.us.leaseweb.net" "5201-5210" "Leaseweb" "Los Angeles, US (10G)" "IPv4|IPv6" \
-		"speedtest.mtl2.ca.leaseweb.net "5201-5210" "Leaseweb" "Montreal, CA (10G)" "IPv4|IPv6"
+		"speedtest.mtl2.ca.leaseweb.net" "5201-5210" "Leaseweb" "Montreal, CA (10G)" "IPv4|IPv6"
 	)
 
 	# if the "REDUCE_NET" flag is activated, then do a shorter iperf test with only three locations

--- a/yabs.sh
+++ b/yabs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Yet Another Bench Script by Mason Rowe
-# Initial Oct 2019; Last update Sep 2023
+# Initial Oct 2019; Last update Oct 2023
 
 # Disclaimer: This project is a work in progress. Any errors or suggestions should be
 #             relayed to me via the GitHub project page linked below.
@@ -12,7 +12,7 @@
 #             performance via fio. The script is designed to not require any dependencies
 #             - either compiled or installed - nor admin privileges to run.
 
-YABS_VERSION="v2023-09-06"
+YABS_VERSION="v2023-10-18"
 
 echo -e '# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## #'
 echo -e '#              Yet-Another-Bench-Script              #'
@@ -821,9 +821,9 @@ if [ -z "$SKIP_IPERF" ]; then
 		"ping6.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv6" \
 		"speedtest.novoserve.com" "5201-5206" "NovoServe" "North Holland, NL (40G)" "IPv4|IPv6" \
 		"speedtest.uztelecom.uz" "5200-5207" "Uztelecom" "Tashkent, UZ (10G)" "IPv4|IPv6" \
-		"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "NYC, NY, US (10G)" "IPv4|IPv6" \
-		"dal.speedtest.clouvider.net" "5200-5209" "Clouvider" "Dallas, TX, US (10G)" "IPv4|IPv6" \
-		"la.speedtest.clouvider.net" "5200-5209" "Clouvider" "Los Angeles, CA, US (10G)" "IPv4|IPv6"
+		"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "New York City, US (10G)" "IPv4|IPv6" \
+		"speedtest.lax11.us.leaseweb.net" "5201-5210" "Leaseweb" "Los Angeles, US (10G)" "IPv4|IPv6" \
+		"speedtest.mtl2.ca.leaseweb.net "5201-5210" "Leaseweb" "Montreal, CA (10G)" "IPv4|IPv6"
 	)
 
 	# if the "REDUCE_NET" flag is activated, then do a shorter iperf test with only three locations
@@ -833,7 +833,7 @@ if [ -z "$SKIP_IPERF" ]; then
 			"lon.speedtest.clouvider.net" "5200-5209" "Clouvider" "London, UK (10G)" "IPv4|IPv6" \
 			"ping.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv4" \
 			"ping6.online.net" "5200-5209" "Scaleway" "Paris, FR (10G)" "IPv6" \
-			"nyc.speedtest.clouvider.net" "5200-5209" "Clouvider" "NYC, NY, US (10G)" "IPv4|IPv6" \
+			"speedtest.lax11.us.leaseweb.net" "5201-5210" "Leaseweb" "Los Angeles, US (10G)" "IPv4|IPv6" \
 		)
 	fi
 	


### PR DESCRIPTION
So far, all `iperf3` servers in the US are provided by Clouvider. While very generous of Clouvider to sponsor all that bandwidth, that unfortunately doesn't provide much diversity in the network tests. Additionally, should Clouvider's network ever encounter some stress (like it just did a few weeks ago), an inexperienced user could easily (and wrongfully) conclude that there are network issues on his end when he sees 4 out of 7 locations yielding bad results. 

Leaseweb now also provides [a broad selection of public `iperf3` servers](https://kb.leaseweb.com/network/link-speeds) since a few months, so there would not even be a need to stick solely to Clouvider anymore for North America. This pull request includes a suggestion of which two Leasweb locations might be a sensible choice for new locations in the US and Canda.


**Why precisely those two?**

- NYC on the east coast, Los Angeles on the west coast, and Montreal in the north to cover a geographically diverse representation of North America.
- Each provider is then only represented by at most two speed test servers anymore. London and NYC stays with Clouvider, Montreal and Los Angeles goes to Leaseweb.


**Are there alternatives worth of consideration?**

Leaseweb also offers speed test servers in APAC region. Given that speed test servers seem generally rare in APAC, it might make sense to "save" Leaseweb for APAC instead (assuming one might want to stick to "two locations per provider max," but I would highly suggest to make this a principle when picking locations in any case).

**How could the output of YABS look after this change?**

Here is a sample of the network section:

```
iperf3 Network Speed Tests (IPv4):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping           
-----           | -----                     | ----            | ----            | ----           
Clouvider       | London, UK (10G)          | 9.29 Gbits/sec  | 6.77 Gbits/sec  | 24.3 ms        
Scaleway        | Paris, FR (10G)           | 6.96 Gbits/sec  | 5.52 Gbits/sec  | 21.0 ms        
NovoServe       | North Holland, NL (40G)   | 9.11 Gbits/sec  | 9.70 Gbits/sec  | 18.5 ms        
Uztelecom       | Tashkent, UZ (10G)        | 3.09 Gbits/sec  | 3.12 Gbits/sec  | 75.1 ms        
Clouvider       | New York City, US (10G)   | 1.80 Gbits/sec  | 1.84 Gbits/sec  | 94.6 ms        
Leaseweb        | Los Angeles, US (10G)     | 1.18 Gbits/sec  | 1.11 Gbits/sec  | 160 ms         
Leaseweb        | Montreal, CA (10G)        | 2.08 Gbits/sec  | 1.91 Gbits/sec  | 97.7 ms        

iperf3 Network Speed Tests (IPv6):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping           
-----           | -----                     | ----            | ----            | ----           
Clouvider       | London, UK (10G)          | 9.89 Gbits/sec  | 7.29 Gbits/sec  | 24.3 ms        
Scaleway        | Paris, FR (10G)           | 7.29 Gbits/sec  | 5.63 Gbits/sec  | 20.7 ms        
NovoServe       | North Holland, NL (40G)   | 8.88 Gbits/sec  | 9.48 Gbits/sec  | 18.5 ms        
Uztelecom       | Tashkent, UZ (10G)        | 3.55 Gbits/sec  | 3.48 Gbits/sec  | 75.2 ms        
Clouvider       | New York City, US (10G)   | 1.83 Gbits/sec  | 1.80 Gbits/sec  | 94.6 ms        
Leaseweb        | Los Angeles, US (10G)     | 1.18 Gbits/sec  | 1.10 Gbits/sec  | 160 ms         
Leaseweb        | Montreal, CA (10G)        | 2.06 Gbits/sec  | 1.89 Gbits/sec  | 97.8 ms        
```

To give it a try yourself, just run the following in a VM:

```curl -sL https://raw.githubusercontent.com/hohl/yet-another-bench-script/patch-3/yabs.sh | bash```
