### PR TITLE
[easy] Fix "tail: cannot open '2' for reading"

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -529,7 +529,7 @@ elif [ -z "$SKIP_FIO" ]; then
 			fi
 		done
 
-		size_b=$(df -Th | grep -w $long | grep -i zfs | awk '{print $5}' | tail -c 2 | head -c 1)
+		size_b=$(df -Th | grep -w $long | grep -i zfs | awk '{print $5}' | tail -c -2 | head -c 1)
 		free_space=$(df -Th | grep -w $long | grep -i zfs | awk '{print $5}' | head -c -2)
 
 		if [[ $size_b == 'T' ]]; then


### PR DESCRIPTION
These messages appear every time YABS is ran on a ZFS partition:

```
tail: cannot open '2' for reading: No such file or directory

Warning! You are running YABS on a ZFS Filesystem and your disk space is too low for the fio test. Your test results will be inaccurate. You need at least 48 GB free in order to complete this test accurately. For more information, please see https://github.com/masonr/yet-another-bench-script/issues/13
```

This is because of a typo in the command that gets the free space suffix ("T" for terabyte or "G" for gigabyte).  `size_b` was always an empty string, which meant it failed the `if` checks on line 535 and 542, which meant it always showed the warning (line 547).

The fix was pretty simple.

For this particular `tail` call, both `tail -c2` and `tail -c -2` are valid... I'm not sure what the original author intended. cc @webdock-io (#20).

It could probably be implemented in a cleaner way by using `awk` for the entire thing instead of a mixture of `grep`, `awk` and `tail`.