### PR TITLE
Use Telia's iperf3 server for Helsinki, FI

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -808,7 +808,7 @@ if [ -z "$SKIP_IPERF" ]; then
 	IPERF_LOCS=( \
 		"lon.speedtest.clouvider.net" "5200-5209" "Clouvider" "London, UK (10G)" "IPv4|IPv6" \
 		"iperf-ams-nl.eranium.net" "5201-5210" "Eranium" "Amsterdam, NL (10G)" "IPv4|IPv6" \
-		"spd-fisrv.hostkey.com" "5200-5209" "HOSTKEY" "Helsinki, FI (10G)" "IPv4" \
+		"speedtest.extra.telia.fi" "5201-5208" "Telia" "Helsinki, FI (10G)" "IPv4" \
 		# AFR placeholder
 		"speedtest.uztelecom.uz" "5200-5209" "Uztelecom" "Tashkent, UZ (10G)" "IPv4|IPv6" \
 		"speedtest.sin1.sg.leaseweb.net" "5201-5210" "Leaseweb" "Singapore, SG (10G)" "IPv4|IPv6" \


### PR DESCRIPTION
I would like to suggest yet another change to the network benchmark: use Telia's `speedtest.extra.telia.fi` for the Helsinki location.

The iperf3 server currently in use for Helsinki doesn't seem capable of going beyond 1G. I haven't yet seen a single YABS output for this destination that was above ~990 Mbps. The iperf3 server of the Finish ISP Telia on the other hand seemed to reliably reach close to 10 Gbps during the tests I performed.