### PR TITLE
Cryptominer937 zfs patch 1

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -267,7 +267,7 @@ TOTAL_SWAP_RAW=$(free | grep Swap | awk '{ print $2 }')
 TOTAL_SWAP=$(format_size "$TOTAL_SWAP_RAW")
 echo -e "Swap       : $TOTAL_SWAP"
 # total disk size is calculated by adding all partitions of the types listed below (after the -t flags)
-TOTAL_DISK_RAW=$(df -t simfs -t ext2 -t ext3 -t ext4 -t btrfs -t xfs -t vfat -t exfat -t ntfs -t swap --total 2>/dev/null | grep total | awk '{ print $2 }')
+TOTAL_DISK_RAW=$(df -t simfs -t ext2 -t ext3 -t ext4 -t zfs -t btrfs -t xfs -t vfat -t exfat -t ntfs -t swap --total 2>/dev/null | grep total | awk '{ print $2 }')
 TOTAL_DISK=$(format_size "$TOTAL_DISK_RAW")
 echo -e "Disk       : $TOTAL_DISK"
 DISTRO=$(grep 'PRETTY_NAME' /etc/os-release | cut -d '"' -f 2 )
@@ -534,53 +534,87 @@ elif [[ -z "$SKIP_FIO" && "$AVAIL_SPACE" -lt 524288 && ("$ARCH" = "aarch64" || "
 elif [ -z "$SKIP_FIO" ]; then
 	# Perform ZFS filesystem detection and determine if we have enough free space according to spa_asize_inflation
 	ZFSCHECK="/sys/module/zfs/parameters/spa_asize_inflation"
-	if [[ -f "$ZFSCHECK" ]];then
-		mul_spa=$(( $(cat /sys/module/zfs/parameters/spa_asize_inflation) * 2 ))
-		warning=0
-		poss=()
+	if [[ -f "$ZFSCHECK" ]]; then
+    # Calculate mul_spa, which is assumed to be an integer (e.g., 2 * 2 = 4)
+    mul_spa=$(( $(cat /sys/module/zfs/parameters/spa_asize_inflation) * 2 ))
+    warning=0
+    poss=()
 
-		for pathls in $(df -Th | awk '{print $7}' | tail -n +2)
-		do
-			if [[ "${PWD##"$pathls"}" != "$PWD" ]]; then
-				poss+=("$pathls")
-			fi
-		done
+    # Find relevant filesystem paths that are parent directories or the current directory itself
+    for pathls in $(df -Th | awk '{print $7}' | tail -n +2)
+    do
+        # Check if PWD starts with (is a subdirectory of or same as) pathls
+        if [[ "${PWD}" == "${pathls}"* ]]; then
+            poss+=("$pathls")
+        fi
+    done
 
-		long=""
-		m=-1
-		for x in "${poss[@]}"
-		do
-			if [ "${#x}" -gt "$m" ];then
-				m=${#x}
-				long=$x
-			fi
-		done
+    long=""
+    m=-1 # Initialize max length to -1 to ensure the first valid path is picked
+    # Select the longest matching path from the 'poss' array
+    # This ensures we get the most specific mounted point for the current directory
+    for x in "${poss[@]}"
+    do
+        if [ "${#x}" -gt "$m" ];then
+            m=${#x}
+            long=$x
+        fi
+    done
 
-		size_b=$(df -Th | grep -w "$long" | grep -i zfs | awk '{print $5}' | tail -c -2 | head -c 1)
-		free_space=$(df -Th | grep -w "$long" | grep -i zfs | awk '{print $5}' | head -c -2)
+    # Proceed only if a relevant ZFS path was found
+    if [[ -n "$long" ]]; then
+        # Get the 'Avail' space directly for the detected path and explicitly for ZFS type
+        # The 'Avail' column is the 4th field in `df -Th` output
+        # Example: '7.3T', '104G', '17G'
+        avail_space_with_unit=$(df -Th | grep -w "$long" | awk '$2 == "zfs" {print $4; exit}')
 
-		if [[ $size_b == 'T' ]]; then
-			free_space=$(awk "BEGIN {print int($free_space * 1024)}")
-			size_b='G'
-		fi
+        # If a valid free space value was extracted
+        if [[ -n "$avail_space_with_unit" ]]; then
+            # Use bash regex to extract the numeric part and the unit
+            # e.g., "7.3T" -> numeric_part="7.3", unit="T"
+            if [[ "$avail_space_with_unit" =~ ^([0-9.]+\.?)([KMGT]?)$ ]]; then
+                numeric_part="${BASH_REMATCH[1]}"
+                unit="${BASH_REMATCH[2]}"
+                # Convert unit to uppercase for consistent case statement matching
+                unit=$(echo "$unit" | tr '[:lower:]' '[:upper:]')
 
-		if [[ $(df -Th | grep -w "$long") == *"zfs"* ]];then
+                # Convert all values to Gigabytes using 'bc -l' for accurate floating-point arithmetic
+                free_space_gb=0
+                case "$unit" in
+                    T) free_space_gb=$(echo "$numeric_part * 1024" | bc -l) ;;
+                    G) free_space_gb=$(echo "$numeric_part" | bc -l) ;;
+                    M) free_space_gb=$(echo "$numeric_part / 1024" | bc -l) ;;
+                    K) free_space_gb=$(echo "$numeric_part / (1024 * 1024)" | bc -l) ;;
+                    # If no unit or 'B' (bytes), assume bytes and convert to GB
+                    B|"") free_space_gb=$(echo "$numeric_part / (1024 * 1024 * 1024)" | bc -l) ;;
+                    *) free_space_gb=0 ;; # Fallback for unexpected units
+                esac
 
-			if [[ $size_b == 'G' ]]; then
-				if ((free_space < mul_spa)); then
-					warning=1
-				fi
-			else
-				warning=1
-			fi
+                # Round the result to the nearest integer for comparison in bash's arithmetic context
+                # printf "%.0f" ensures it's an integer string.
+                free_space_gb_int=$(awk "BEGIN {printf \"%.0f\", $free_space_gb}")
 
-		fi
+                # Now, perform the arithmetic comparison with the integer free_space_gb_int
+                if ((free_space_gb_int < mul_spa)); then
+                    warning=1
+                fi
+            else
+                # Handle case where avail_space_with_unit doesn't match expected format
+                echo "Warning: Could not parse free space format for $long: '$avail_space_with_unit'"
+                # Potentially set warning=1 here if unparseable space is critical
+            fi
+        else
+            echo "Warning: No ZFS entry found for path $long or could not extract available space."
+        fi
+    else
+        echo "Note: No relevant filesystem path detected for current directory ($PWD)."
+    fi
 
-		if [[ $warning -eq 1 ]];then
-			echo -en "\nWarning! You are running YABS on a ZFS Filesystem and your disk space is too low for the fio test. Your test results will be inaccurate. You need at least $mul_spa GB free in order to complete this test accurately. For more information, please see https://github.com/masonr/yet-another-bench-script/issues/13\n"
-		fi
-	fi
-	
+    # Display warning if conditions are met
+    if [[ $warning -eq 1 ]];then
+        echo -en "\nWarning! You are running YABS on a ZFS Filesystem and your disk space is too low for the fio test. Your test results will be inaccurate. You need at least $mul_spa GB free in order to complete this test accurately. For more information, please see https://github.com/masonr/yet-another-bench-script/issues/13\n"
+    fi
+fi	
 	echo -en "\nPreparing system for disk tests..."
 
 	# create temp directory to store disk write/read test files


### PR DESCRIPTION
re-wrote ZFSCHECK to handle large disks more cleanly and to prevent errors like

bash: line 570: ((: 7.3T
17: syntax error: invalid arithmetic operator (error token is ".3T
17")

I originally used bc but changed it to awk cause not all systems will have bc.

Also added -t zfs so it will display free space in the summary for zfs disks.

Commented as best I can

Tested on Debian 12, Ubuntu 22.04 / 24.04, and Proxmox VE 8.4.1