### PR TITLE
Feats: Add Custom Iperf3 Server Option

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -8,7 +8,7 @@
 #
 # Purpose:    The purpose of this script is to quickly gauge the performance of a Linux-
 #             based server by benchmarking network performance via iperf3, CPU and
-#             overall system performance via Geekbench 4/5, and random disk
+#             overall system performance via Geekbench 4/5/6, and random disk
 #             performance via fio. The script is designed to not require any dependencies
 #             - either compiled or installed - nor admin privileges to run.
 

--- a/yabs.sh
+++ b/yabs.sh
@@ -151,7 +151,7 @@ if [ -n "$PRINT_HELP" ]; then
 	echo -e "       -s <url> : send jsonified YABS results to URL"
 	echo -e "       -p <servers> : specify custom iperf servers (format: host:port_range:name:location:network_modes)"
 	echo -e "                      multiple servers separated by commas"
-	echo -e "                      example: -p \"example.com:5201-5210:MyServer:New York, NY (10G):IPv4|IPv6\""
+	echo -e "                      example: -p \"example.com:5201-5210:MyServer:New York (10G):IPv4|IPv6\""
 	echo -e
 	echo -e "Detected Arch: $ARCH"
 	echo -e


### PR DESCRIPTION
This PR introduces a new command-line argument, `-p`, to the `yabs.sh` script. This argument allows users to specify custom Iperf3 servers to use for network speed tests, overriding the default server list. This provides greater flexibility for users who may want to test against servers closer to their location, or servers with specific configurations.

You can test this PR using public servers, for example on the page: [https://iperf.fr/iperf-servers.php](https://iperf.fr/iperf-servers.php)

**Changes:**

*   **Added `-p` argument parsing in `getopts`:** The `getopts 'bfdignhr4596jw:s:p:' flag` line now includes `p` to recognize the new argument.
*   **`IPERF_SERVERS` variable:** A new variable `IPERF_SERVERS` stores the value passed to the `-p` argument.
*   **Help message updated:** The `-h` flag output has been updated to explain the usage of the `-p` argument, including the expected format for server definitions.
*   **Custom server list parsing and integration:**  The parsing block allows parameters to be read, separated by commas, host:port_range:name:location:network_modes is the expected format.
*   **Logic added to prioritize custom servers:** The `launch_iperf` function now checks for the existence of `IPERF_SERVERS`. If defined, it replaces the default `IPERF_LOCS` array with the custom servers parsed from the user's input.

**Usage:**

The `-p` argument accepts a comma-separated list of Iperf3 server definitions. Each server definition must conform to the following format:

host:port_range:name:location:network_modes

Where:

*   `host`: The hostname or IP address of the Iperf3 server.
*   `port_range`: The range of ports the Iperf3 server is listening on (e.g., `5201-5210`).
*   `name`: A friendly name for the Iperf3 server (e.g., `MyServer`).
*   `location`: The location of the Iperf3 server (e.g., `New York, NY`).
*   `network_modes`: Network modes supported by the iperf server (IPv4, IPv6, or IPv4|IPv6).

**Example:**

```bash
./yabs.sh -gd -p "ping.online.net:5200-5209:Scaleway:DC3 France (Paris):IPv4,paris.bbr.iperf.bytel.fr:9200-9240:Bouygues:France (Paris):IPv4|IPv6"
```

**Output:**

```bash
[...]

iperf3 Network Speed Tests (IPv4):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping
-----           | -----                     | ----            | ----            | ----
Scaleway        | DC3 France (Paris)        | 917 Mbits/sec   | 928 Mbits/sec   | 21.2 ms
Bouygues        | France (Paris)            | 916 Mbits/sec   | 940 Mbits/sec   | --

iperf3 Network Speed Tests (IPv6):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping
-----           | -----                     | ----            | ----            | ----
Bouygues        | France (Paris)            | 919 Mbits/sec   | 923 Mbits/sec   | --

[...]
```

**Update -h help message:**
```bash

Flags:
[...]
       -s <url> : send jsonified YABS results to URL
       -p <servers> : specify custom iperf servers (format: host:port_range:name:location:network_modes)
                      multiple servers separated by commas
                      example: -p "example.com:5201-5210:MyServer:New York (10G):IPv4|IPv6"

[...]
```
