### PR TITLE
Fix: iperf_test latency measurement ignores IPv4/IPv6 (see Issue 121)

### DIFF
--- a/yabs.sh
+++ b/yabs.sh
@@ -798,7 +798,7 @@ function iperf_test {
 	done
 
 	# Run a latency test via ping -c1 command -> will return "xx.x ms"
-	[[ -n $LOCAL_PING ]] && LATENCY_RUN="$(ping -c1 "$URL" 2>/dev/null | grep -o 'time=.*' | sed s/'time='//)"
+	[[ -n $LOCAL_PING ]] && LATENCY_RUN="$(ping $FLAGS -c1 "$URL" 2>/dev/null | grep -o 'time=.*' | sed s/'time='//)"
 	[[ -z $LATENCY_RUN ]] && LATENCY_RUN="--"
 
 	# parse the resulting send and receive speed results


### PR DESCRIPTION
Fix for [issue 121](https://github.com/masonr/yet-another-bench-script/issues/121) reported by @yoursunny.

`iperf_test` currently only calls `ping -c1 $URL`. It doesn't define whether we want to measure IPv4 or IPv6 latency. Yet, the output presents it as if we once measured IPv4 latency and IPv6 latency separately. In reality, it just measures the same thing twice and for the most scenarios will be closely related anyways. This patch fixes this misleading behaviour by applying either `-4` or `-6` as parameter when calling `ping -c1`.